### PR TITLE
adding visual indicator to tmux statusline to tmix-modal is activated

### DIFF
--- a/tmux-modal.tmux
+++ b/tmux-modal.tmux
@@ -583,7 +583,7 @@ STATUS_LEFT=`
       `'?#{==:'$KT_PREFIX'-,'`
          `'#{='$((${#KT_PREFIX} + 1))':client_key_table}'`
         `'},'`
-       `$MODAL_ICON' ,'`
+       `'#[bg=#ff0125]'$MODAL_ICON' ,'`
      `'}'
 
 # We want to set the left status bar once; do it only if we can't find our


### PR DESCRIPTION
This pull request is based on the issue I opened [here](https://github.com/whame/tmux-modal/issues/6#issue-1315994484). I thought others might find it useful. The `bg` value can also be exposed to the user if need be.