### PR TITLE
Allow for Options to be passed to split-window

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,3 +276,14 @@ The left status bar will now update to match the tmux-modal command currently in
 use. For example, if you press `w` the status bar will change from the modal
 command icon `[=]` to `[w]` (the window command). If you now further press `s`,
 it will update to `[ws]` to signify the split window command sequence and so on.
+
+### Add Options to Split Command
+
+The option `@modal-split-opts` can be set in `.tmux.conf` to give allow control
+over options passed to split:
+
+```
+# use the current pane path as working directory for new splits
+set -g @modal-split-opts "-c \"#{pane_current_path}\""
+```
+

--- a/tmux-modal.tmux
+++ b/tmux-modal.tmux
@@ -417,6 +417,13 @@ elif ! parse_yn_opt "$SHOW_CMD_KEYS_VAL" $SHOW_CMD_KEYS_OPT; then
     exit 22
 fi
 
+# allow override of split options
+SPLIT_OPT=@modal-split-opts
+SPLIT_VAL=$(tmux show-options -g -v -q $SPLIT_OPT)
+if [ -z "$SPLIT_VAL" ]; then
+    SPLIT_VAL=""
+fi
+
 # Create keybinding file to be sourced by tmux.
 
 KBD_FILE="$CURRENT_DIR/.kbd.conf"
@@ -541,8 +548,8 @@ EOF
 # window-split.
 cat << EOF >> "$KBD_FILE"
 
-bind-key -T $KT_WIN_SPLIT $KBD_WIN_SPLIT_RIGHT split-window -h
-bind-key -T $KT_WIN_SPLIT $KBD_WIN_SPLIT_DOWN split-window
+bind-key -T $KT_WIN_SPLIT $KBD_WIN_SPLIT_RIGHT split-window -h $SPLIT_VAL
+bind-key -T $KT_WIN_SPLIT $KBD_WIN_SPLIT_DOWN split-window $SPLIT_VAL
 EOF
 
 # window-move.


### PR DESCRIPTION
I like to have splits open in the current working directory. 
```split-window -h -c "#{pane_current_path}"```

Not everyone might like that so I made it an option `@modal-split-opts` , and made the configuration copy and paste for others in case they like it. Also this keeps the configuration backwards compatible with no breaking changes.